### PR TITLE
Deploy lambda now waits for stack create/update

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ exports.handler = function(event, context) {
         }, function(err, data){
             if (err) {
                 console.log(err, err.stack);
-                reject(err);
+                exitFailure(`Failed to check status of stack: ${err.message}`);
             } else {
                 console.log(data)
                 let stackStatus = data.Stacks[0].StackStatus;


### PR DESCRIPTION
# Summary

When the lambda function updates a CloudFormation stack it does not wait to check its status.

# Details

This will use the **putJobSuccessResult** method with *continuationToken* to notify the CodePipeline that this job can take some time and it will ask again later for its status.

# References:

* http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CodePipeline.html#putJobSuccessResult-property
* http://docs.aws.amazon.com/codepipeline/latest/APIReference/API_PutJobSuccessResult.html

# Gotchas

* There is one edge case, which shouldn't happen since we should never change stuff manually.
> Because the SDK and the CodePipeline integration is using polling to check the CloudFormation stack status and we don't have any ID or token to validate the status of **our** update, if someone does something manually this can check the wrong update.
